### PR TITLE
Prevents players from selling lore items

### DIFF
--- a/EconomyShopGUI/config.yml
+++ b/EconomyShopGUI/config.yml
@@ -301,7 +301,7 @@ sellgui-nav-bar:
 allow-renamed-items: true
 
 # Allows items with different lore to be sold to the shop
-allow-lore-items: true
+allow-lore-items: false
 
 # Enable/disable the lore on items given to players when an item is bought from shop
 bought-items-lore: true


### PR DESCRIPTION
lore items shouldn't be sellable as they're important items that should only be traded, passed around, or if a player decides, deleted using vanilla means.