### PR TITLE
Removed Void Damage Blacklist

### DIFF
--- a/ReviveMe/config.yml
+++ b/ReviveMe/config.yml
@@ -117,7 +117,7 @@ commands_config:
 # Here you can choose what types of damage ReviveMe should ignore in case the mode is blacklist or what types of damage should be for it to work in case of whitelist
 # damages list: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html
 damages_type:
-  enabled: true
+  enabled: false
   mode: Blacklist
   list:
   - void

--- a/ReviveMe/downed_interacts.yml
+++ b/ReviveMe/downed_interacts.yml
@@ -13,10 +13,10 @@ enable_damage: false
 enable_entity_interact: true
 
 #can the downed player break blocks?
-enable_block_break: true
+enable_block_break: false
 
 #can the downed player place blocks?
-enable_block_place: true
+enable_block_place: false
 
 #can the downed player interact?
 enable_interact: true
@@ -25,25 +25,25 @@ enable_interact: true
 enable_move: true
 
 #can the downed player teleport?
-enable_teleport: true
+enable_teleport: false
 
 #can the downed player shoot with a bow?
-enable_shoot_bow: true
+enable_shoot_bow: false
 
 #can the downed player launch projectiles?
-enable_projectile_launch: true
+enable_projectile_launch: false
 
 #downed player can be damaged by falling?
 enable_fall_damage: false
 
 #Can the downed player drop items?
-enable_item_drop: true
+enable_item_drop: false
 
 #Can the downed player pick up items?
 enable_item_pickup: true
 
 #Can the downed player use the elytra?
-enable_gliding: true
+enable_gliding: false
 
 #Maximum distance for the player to be knocked down with fall damage. If the distance fallen is greater than this value, the player will die instantly.
 #put -1 to disable this option. if the option is disabled the player will be knocked down no matter how far they fell


### PR DESCRIPTION
We shouldn't have void damage blacklisted, or it can cause cases where knocked players will fall thousands of blocks into the void pointlessly (just let them die at that point, no one can save them, nor should they be able to)

Edited Downed Interacts, you should not be able to drop your items, or break blocks, or most of these interacts as a downed player, you're DOWNED not supposed to be able to play the game.