### PR TITLE
[QoL] Improved Auction Config

### DIFF
--- a/AuctionHouse/config.yml
+++ b/AuctionHouse/config.yml
@@ -31,13 +31,13 @@ auction setting:
     max auction increment price: 1000000000
 
     # The min price for buy only / buy now items
-    min auction price: 1
+    min auction price: 0
 
     # The min price starting a bidding auction
-    min auction start price: 1
+    min auction start price: 0
 
     # The min amount for incrementing a bid.
-    min auction increment price: 1
+    min auction increment price: 100
   purchase:
 
     # Should the owner of an auction be able to purchase it?


### PR DESCRIPTION
Allows users to sell items for free, and increases minimum auction price increments (increasing bids by $1 to indefinitely increase the length of bidding seems a bit absurd, whereas you could just sell an item for buy now if you wanted it for free or if you had a cheap price sell it for that cheap price instead of making people bid $1-2 -_-)