### PR TITLE
[QoL] Fixed Tools chat message spam - [Bug] Removed vanished player's collisions

### DIFF
--- a/SuperVanish/config.yml
+++ b/SuperVanish/config.yml
@@ -20,7 +20,7 @@ InvisibilityFeatures:
   DisablePressurePlates: true
   # Should invisible players not be able to push other players or be able to be pushed?
   # WARNING: Uses the scoreboard and may conflict with other plugins!
-  DisablePush: false
+  DisablePush: true
   # Should vanished players pick up items by default? This can be changed individually with /sv tipu
   DefaultPickUpItemsOption: false
   # Should SV modify tablist packets to prevent the server from leaking who is online?

--- a/ToolStats/config.yml
+++ b/ToolStats/config.yml
@@ -95,7 +95,7 @@ messages:
   # Display this message if the player shift click trades/crafts items. It's not really easy to get every single item
   # that is crafted. The tag will only be added to the first item. If you don't want this message, simply replace them both with ""
   shift-click-warning:
-    crafting: "&cCrafting items via shift clicking does not fully apply tags to each item. This is a limitation with the Bukkit API."
-    trading: "&cTrading items via shift clicking does not fully apply tags to each item. This is a limitation with the Bukkit API."
+    crafting: ""
+    trading: ""
 
 config-version: 3


### PR DESCRIPTION
Removed "shift clicking doesnt allow tags to be properly applied" message, as it is annoying and pointless.
(you're welcome nev)

Removed Vanished players collisions to prevent unintended mishaps
